### PR TITLE
Fix numpy dependency error by pinning to less than 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docling-core
 huggingface_hub
 Pillow
 python-dotenv
+numpy<2


### PR DESCRIPTION
Hi @AIAnytime team! I was able to clone and run the streamlit app. I ran into minor issue with numpy version as none of the versions are pinned. This simple change worked for me.

This repo has been very helpful to get me started with SmolDocling. I have a bunch of PDF files. Do you plan to add support for taking in PDF directly and converting to Images? Happy to help push a PR your way if I end up extending this repository.